### PR TITLE
[Add]: Handle lagged connection during transaction streaming responses

### DIFF
--- a/backend/src/redis_client.py
+++ b/backend/src/redis_client.py
@@ -1,5 +1,10 @@
 import redis
+from redis.asyncio import Redis as AsyncRedis
 
 
 def get_redis_client():
     return redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+
+def get_async_redis_client():
+    return AsyncRedis(host="localhost", port=6379, decode_responses=True)


### PR DESCRIPTION
This PR addresses #3 

Prior to this PR, adding a transaction and slowly switching (for whatever reasons) to the streaming endpoint may cause clients to miss out on receiving updates

PR will use `rpush` from redis to store the transactions temporarily with a 2min TTL and client can receive any missed out updates