### PR TITLE
[Fix]: Ordering of transactions when adding transactions

### DIFF
--- a/frontend/hooks/category/useCreateCategoryMutation.tsx
+++ b/frontend/hooks/category/useCreateCategoryMutation.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { CategoryKey } from "app/(tabs)/profile/categories";
 import { BaseURL } from "constants/BaseUrl";
+import { CategoryKey } from "keys/category";
 import { CreateCategoryMutationProps } from "types/category";
 
 export const useCreateCategoryMutation = () => {

--- a/frontend/utils.ts
+++ b/frontend/utils.ts
@@ -139,8 +139,12 @@ export function autoCompleteJSON(jsonString: string) {
 export const formatTransactions = (data: TransactionProps[]) => {
   const transactionByDate: Record<string, TransactionByDateProps> = {};
 
-  for (let i = 0; i < data.length; i++) {
-    const transaction = data[i];
+  const sortedData = [...data].sort(
+    (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+  );
+
+  for (let i = 0; i < sortedData.length; i++) {
+    const transaction = sortedData[i];
     const { amount, date, entry_type } = transaction;
     const transactionDate = new Date(date);
     const formattedDate = transactionDate.toISOString().split("T")[0];


### PR DESCRIPTION
#14 

This PR will fix the order of transactions when adding different dates within the AddTransaction page. It was previously not sorted as each transactions may be inserted at different points with different dates. Now with every entry of transactions, it will be sorted